### PR TITLE
set json logger version compatible with base

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ setup(
     version='0.1.0',
     description='Givelify Structured logging library',
     author='Me',
-    install_requires=['python-json-logger==2.0.2'],
+    install_requires=['python-json-logger==2.0.7'],
     setup_requires=['pytest-runner'],
     extras_require={  # Optional
         "dev": ["check-manifest"],


### PR DESCRIPTION
Our base python image has a requirement of python-json-logger==2.0.7 while this package has requirement of python-json-logger==2.0.2.

This conflict prevents the deps from being installed. Updating the requirements of this package to 2.0.7.

![image](https://github.com/user-attachments/assets/aa6dc763-c629-467a-81de-c93a21dc7ff6)
