### PR TITLE
Support logging exception tracebacks with exc_info

### DIFF
--- a/givelifylogging/StructuredLogger.py
+++ b/givelifylogging/StructuredLogger.py
@@ -1,32 +1,37 @@
-import logging
 import datetime
+import logging
 import os
 from logging.handlers import TimedRotatingFileHandler
+
 from givelifylogging.CustomJsonFormatter import CustomJsonFormatter
+
 
 class StructuredLogger:
     def __init__(self, base_logger):
         self.logger = base_logger
-        formatted_log_filename = f"logFile-{datetime.datetime.now().strftime('%Y-%m-%d')}.log"
-        self.filepath = os.path.join('.logs', formatted_log_filename)
+        formatted_log_filename = (
+            f"logFile-{datetime.datetime.now().strftime('%Y-%m-%d')}.log"
+        )
+        self.filepath = os.path.join(".logs", formatted_log_filename)
 
     def setLogFile(self, filepath):
         self.filepath = filepath
-    
+
     def getLogFile(self):
         return self.filepath
-    
-    def log(self, message, type_="generic", value=None, level=logging.INFO):
+
+    def log(
+        self, message, type_="generic", value=None, level=logging.INFO, exc_info=False
+    ):
         if value is None:
             value = {}
         context_data = {
             "givelifyEventId": None,
-            "entity": {
-                "type": type_,
-                "value": value
-            }
+            "entity": {"type": type_, "value": value},
         }
-        self.logger.log(level, message, extra={"context": context_data})
+        self.logger.log(
+            level, message, extra={"context": context_data}, exc_info=exc_info
+        )
 
     def info(self, message, type_="generic", value=None):
         self.log(message, type_, value, logging.INFO)
@@ -34,8 +39,8 @@ class StructuredLogger:
     def warn(self, message, type_="generic", value=None):
         self.log(message, type_, value, logging.WARNING)
 
-    def error(self, message, type_="generic", value=None):
-        self.log(message, type_, value, logging.ERROR)
+    def error(self, message, type_="generic", value=None, exc_info=False):
+        self.log(message, type_, value, logging.ERROR, exc_info=exc_info)
 
     def debug(self, message, type_="generic", value=None):
         self.log(message, type_, value, logging.DEBUG)
@@ -43,11 +48,15 @@ class StructuredLogger:
     def critical(self, message, type_="generic", value=None):
         self.log(message, type_, value, logging.CRITICAL)
 
-    def getLogger(__name__, loglevelstr='INFO', handler=None, folder='.logs', filename='logFile'):
+    def getLogger(
+        __name__, loglevelstr="INFO", handler=None, folder=".logs", filename="logFile"
+    ):
         if not os.path.exists(folder):
             os.makedirs(folder)
 
-        formatted_log_filename = f"{filename}-{datetime.datetime.now().strftime('%Y-%m-%d')}.log"
+        formatted_log_filename = (
+            f"{filename}-{datetime.datetime.now().strftime('%Y-%m-%d')}.log"
+        )
         log_file = os.path.join(folder, formatted_log_filename)
 
         base_logger = logging.getLogger(__name__)
@@ -60,11 +69,16 @@ class StructuredLogger:
         base_logger.setLevel(loggingLevel)
 
         if not handler:
-            handler = TimedRotatingFileHandler(log_file, when="midnight", interval=1, backupCount=3, encoding='utf-8')
+            handler = TimedRotatingFileHandler(
+                log_file, when="midnight", interval=1, backupCount=3, encoding="utf-8"
+            )
             handler.suffix = "%Y-%m-%d.log"
 
         # formatter = CustomJsonFormatter('(message) (levelname) (name) (asctime)', datefmt='%Y-%m-%d %H:%M:%S')
-        formatter = CustomJsonFormatter('{"message": "%(message)s", "level": "%(levelname)s", "name": "%(name)s", "asctime": "%(asctime)s"}', datefmt='%Y-%m-%d %H:%M:%S')
+        formatter = CustomJsonFormatter(
+            '{"message": "%(message)s", "level": "%(levelname)s", "name": "%(name)s", "asctime": "%(asctime)s"}',
+            datefmt="%Y-%m-%d %H:%M:%S",
+        )
 
         handler.setFormatter(formatter)
         base_logger.addHandler(handler)
@@ -73,5 +87,3 @@ class StructuredLogger:
         logger.setLogFile(log_file)
 
         return logger
-    
-

--- a/givelifylogging/StructuredLogger.py
+++ b/givelifylogging/StructuredLogger.py
@@ -18,33 +18,32 @@ class StructuredLogger:
     def getLogFile(self):
         return self.filepath
     
-    def log(
-        self, message, type_="generic", value=None, level=logging.INFO, exc_info=False
-    ):
+    def log(self, message, type_="generic", value=None, level=logging.INFO, exc_info=False):
         if value is None:
             value = {}
         context_data = {
             "givelifyEventId": None,
-            "entity": {"type": type_, "value": value},
+            "entity": {
+                "type": type_,
+                "value": value
+            },
         }
-        self.logger.log(
-            level, message, extra={"context": context_data}, exc_info=exc_info
-        )
+        self.logger.log(level, message, extra={"context": context_data}, exc_info=exc_info)
 
-    def info(self, message, type_="generic", value=None):
-        self.log(message, type_, value, logging.INFO)
+    def info(self, message, type_="generic", value=None, exc_info=False):
+        self.log(message, type_, value, logging.INFO, exc_info=exc_info)
 
-    def warn(self, message, type_="generic", value=None):
-        self.log(message, type_, value, logging.WARNING)
+    def warn(self, message, type_="generic", value=None, exc_info=False):
+        self.log(message, type_, value, logging.WARNING, exc_info=exc_info)
 
     def error(self, message, type_="generic", value=None, exc_info=False):
         self.log(message, type_, value, logging.ERROR, exc_info=exc_info)
 
-    def debug(self, message, type_="generic", value=None):
-        self.log(message, type_, value, logging.DEBUG)
+    def debug(self, message, type_="generic", value=None, exc_info=False):
+        self.log(message, type_, value, logging.DEBUG, exc_info=exc_info)
 
-    def critical(self, message, type_="generic", value=None):
-        self.log(message, type_, value, logging.CRITICAL)
+    def critical(self, message, type_="generic", value=None, exc_info=False):
+        self.log(message, type_, value, logging.CRITICAL, exc_info=exc_info)
 
     def getLogger(__name__, loglevelstr='INFO', handler=None, folder='.logs', filename='logFile'):
         if not os.path.exists(folder):

--- a/givelifylogging/StructuredLogger.py
+++ b/givelifylogging/StructuredLogger.py
@@ -9,17 +9,15 @@ from givelifylogging.CustomJsonFormatter import CustomJsonFormatter
 class StructuredLogger:
     def __init__(self, base_logger):
         self.logger = base_logger
-        formatted_log_filename = (
-            f"logFile-{datetime.datetime.now().strftime('%Y-%m-%d')}.log"
-        )
-        self.filepath = os.path.join(".logs", formatted_log_filename)
+        formatted_log_filename = f"logFile-{datetime.datetime.now().strftime('%Y-%m-%d')}.log"
+        self.filepath = os.path.join('.logs', formatted_log_filename)
 
     def setLogFile(self, filepath):
         self.filepath = filepath
-
+    
     def getLogFile(self):
         return self.filepath
-
+    
     def log(
         self, message, type_="generic", value=None, level=logging.INFO, exc_info=False
     ):
@@ -48,15 +46,11 @@ class StructuredLogger:
     def critical(self, message, type_="generic", value=None):
         self.log(message, type_, value, logging.CRITICAL)
 
-    def getLogger(
-        __name__, loglevelstr="INFO", handler=None, folder=".logs", filename="logFile"
-    ):
+    def getLogger(__name__, loglevelstr='INFO', handler=None, folder='.logs', filename='logFile'):
         if not os.path.exists(folder):
             os.makedirs(folder)
 
-        formatted_log_filename = (
-            f"{filename}-{datetime.datetime.now().strftime('%Y-%m-%d')}.log"
-        )
+        formatted_log_filename = f"{filename}-{datetime.datetime.now().strftime('%Y-%m-%d')}.log"
         log_file = os.path.join(folder, formatted_log_filename)
 
         base_logger = logging.getLogger(__name__)
@@ -69,16 +63,11 @@ class StructuredLogger:
         base_logger.setLevel(loggingLevel)
 
         if not handler:
-            handler = TimedRotatingFileHandler(
-                log_file, when="midnight", interval=1, backupCount=3, encoding="utf-8"
-            )
+            handler = TimedRotatingFileHandler(log_file, when="midnight", interval=1, backupCount=3, encoding='utf-8')
             handler.suffix = "%Y-%m-%d.log"
 
         # formatter = CustomJsonFormatter('(message) (levelname) (name) (asctime)', datefmt='%Y-%m-%d %H:%M:%S')
-        formatter = CustomJsonFormatter(
-            '{"message": "%(message)s", "level": "%(levelname)s", "name": "%(name)s", "asctime": "%(asctime)s"}',
-            datefmt="%Y-%m-%d %H:%M:%S",
-        )
+        formatter = CustomJsonFormatter('{"message": "%(message)s", "level": "%(levelname)s", "name": "%(name)s", "asctime": "%(asctime)s"}', datefmt='%Y-%m-%d %H:%M:%S')
 
         handler.setFormatter(formatter)
         base_logger.addHandler(handler)


### PR DESCRIPTION
This change adds support for an optional exc_info parameter to the StructuredLogger, enabling stacktrace logging when exceptions occur. This will be useful for debugging and monitoring in production environments.